### PR TITLE
Fix for bug with find_by_id returning None on on_signal()

### DIFF
--- a/i3-swap-focus
+++ b/i3-swap-focus
@@ -19,6 +19,7 @@ async def on_signal(i3):
             current_workspace = (await i3.get_tree()).find_focused().workspace().id
             window_workspace = (await i3.get_tree()).find_by_id(window_id).workspace().id
             if current_workspace != window_workspace:
+                window_stack.append(window_id)
                 return
         cmd = f'[con_id={window_id}] focus'
         await i3.command(cmd)


### PR DESCRIPTION
This bug fix adresses issue #2 

I'm just avoiding an empty stack when using the option --stay-in-workspace

I haven't tested it with python >= 3.7 and I don't know if this bug occurs in those versions so I think it would be good to test it before merging this bug fix. 